### PR TITLE
fix: 리뷰 좋아요 기능 로직 오류 수정

### DIFF
--- a/src/features/review/review.controller.ts
+++ b/src/features/review/review.controller.ts
@@ -29,7 +29,7 @@ export class ReviewController {
 
   @Post(':reviewId/likes')
   async likeReview(
-    @Param('reviewid', ParseBigIntPipe) reviewId: bigint,
+    @Param('reviewId', ParseBigIntPipe) reviewId: bigint,
     @Req() req: RequestWithUser,
   ) {
     const memberId = BigInt(req.user.id);

--- a/src/features/review/review.repository.ts
+++ b/src/features/review/review.repository.ts
@@ -41,7 +41,6 @@ export class ReviewRepository {
       });
 
       await prisma.$queryRawTyped(
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-call
         upsertStudyFlag(
           memberId,
           review.article.keywordId,
@@ -245,9 +244,13 @@ export class ReviewRepository {
   }
 
   async likeReview(memberId: bigint, reviewId: bigint) {
+    console.log('>>>>>');
     await this.prismaService.likeReview.upsert({
       where: {
-        id: reviewId,
+        reviewId_memberId: {
+          memberId,
+          reviewId,
+        },
       },
       update: {},
       create: {


### PR DESCRIPTION
리뷰 좋아요 요청 보냈을 시, prisma 에서 `upsert` 할 때 `where` 조건에 오류가 있어서 수정했습니다.